### PR TITLE
Update opsworks agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The main goal of this project is building vagrant boxes for developing & testing cookbooks you plan to use in Amazon Opsworks.
 
-Use this project to build a Ubuntu 14.04 LTS (or Ubuntu 12.04.5 LTS) box provisioned with opsworks ruby2.0.0-p481 and chef 11.10.4 from agent release 336.
+Use this project to build a Ubuntu 14.04 LTS (or Ubuntu 12.04.5 LTS) box provisioned with opsworks ruby2.0.0-p481 and chef 11.10.4 from agent release 3425.
 
 You may have noticed the new opsworks agent using chef-client with chef-zero now, be aware this box only provides chef-solo.
 

--- a/provision/opsworks.sh
+++ b/provision/opsworks.sh
@@ -7,7 +7,7 @@ cp opsworks/* /var/lib/aws/opsworks/
 
 # download and install opsworks-agent and all support files
 cd $(mktemp -d)
-wget -O opsworks-agent.tgz https://opsworks-instance-agent.s3.amazonaws.com/33600020150210181912/opsworks-agent-installer.tgz
+wget -O opsworks-agent.tgz https://opsworks-instance-agent.s3.amazonaws.com/3425-20150727112318/opsworks-agent-installer.tgz
 tar -xvzpof opsworks-agent.tgz
 cd opsworks-agent-installer/opsworks-agent/bin/
 ./installer_wrapper.sh -R opsworks-instance-assets.s3.amazonaws.com


### PR DESCRIPTION
Update OpsWorks agent to version 3425 

See [CHANGELOG](https://opsworks-instance-agent.s3.amazonaws.com/3425-20150727112318/opsworks-agent-installer.tgz-CHANGELOG.md) for changes history