### PR TITLE
Remove some redundant commands

### DIFF
--- a/provision/base.sh
+++ b/provision/base.sh
@@ -1,25 +1,9 @@
+# change the default frontend of debconf
+export DEBIAN_FRONTEND=noninteractive
+
 # enable multiverse repositories
-code_name=`lsb_release -c | awk '{ print $2 }'`
-  cat <<EOM > /etc/apt/sources.list.d/$code_name-multiverse.list
-  deb http://archive.ubuntu.com/ubuntu/ $code_name main universe
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name main universe
-  deb http://archive.ubuntu.com/ubuntu/ $code_name-updates main universe
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name-updates main universe
-  deb http://archive.ubuntu.com/ubuntu $code_name-security main universe
-  deb-src http://archive.ubuntu.com/ubuntu $code_name-security main universe
-  deb http://archive.ubuntu.com/ubuntu/ $code_name multiverse
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name multiverse
-  deb http://archive.ubuntu.com/ubuntu/ $code_name-updates multiverse
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name-updates multiverse
-  deb http://archive.ubuntu.com/ubuntu $code_name-security multiverse
-  deb-src http://archive.ubuntu.com/ubuntu $code_name-security multiverse
-  deb http://archive.ubuntu.com/ubuntu/ $code_name multiverse
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name multiverse
-  deb http://archive.ubuntu.com/ubuntu/ $code_name-updates multiverse
-  deb-src http://archive.ubuntu.com/ubuntu/ $code_name-updates multiverse
-  deb http://security.ubuntu.com/ubuntu $code_name-security multiverse
-  deb-src http://security.ubuntu.com/ubuntu $code_name-security multiverse
-EOM
+apt-get install -y software-properties-common
+add-apt-repository multiverse
 
 # update the package repository
 apt-get update

--- a/provision/vagrant.sh
+++ b/provision/vagrant.sh
@@ -1,10 +1,5 @@
 date > /etc/vagrant_box_build_time
 
-# Vagrant user
-/usr/sbin/groupadd vagrant
-/usr/sbin/useradd vagrant -g vagrant -G sudo -d /home/vagrant --create-home
-echo "vagrant:vagrant" | chpasswd
-
 # Set up sudo.  Be careful to set permission BEFORE copying file to sudoers.d
 ( cat <<'EOP'
 %vagrant ALL=NOPASSWD:ALL


### PR DESCRIPTION
I removed the user creation commands from the provisioning scripts because they are already created in the packer template. In addition, I added a better way to enable multiverse repositories with add-apt-repositories. 
